### PR TITLE
Potential fix for code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/examples/airpods-pitch-website.html
+++ b/examples/airpods-pitch-website.html
@@ -1084,6 +1084,16 @@
             });
         }
 
+        // Helper to escape HTML special characters
+        function escapeHTML(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         // Interactive demo functionality
         let activeDevice = null;
 
@@ -1099,7 +1109,7 @@
             
             // Update status text
             const statusElement = document.getElementById('demo-status');
-            statusElement.innerHTML = `<span style="color: #06d6a0;">🎵 Now playing audio from ${deviceName}</span>`;
+            statusElement.innerHTML = `<span style="color: #06d6a0;">🎵 Now playing audio from ${escapeHTML(deviceName)}</span>`;
             
             // Create connection line animation
             createConnectionLine(element);
@@ -1180,7 +1190,7 @@
             activateDevice(randomDevice, deviceName);
             
             const statusElement = document.getElementById('demo-status');
-            statusElement.innerHTML = `<span style="color: #667eea;">🔄 Automatically switched to ${deviceName}</span>`;
+            statusElement.innerHTML = `<span style="color: #667eea;">🔄 Automatically switched to ${escapeHTML(deviceName)}</span>`;
         }
 
         // Create floating particles


### PR DESCRIPTION
Potential fix for [https://github.com/joanalnu/joanalnu.github.io/security/code-scanning/25](https://github.com/joanalnu/joanalnu.github.io/security/code-scanning/25)

To fix the vulnerability, we must ensure that any value interpolated into an HTML string and assigned to `innerHTML` is properly escaped to prevent HTML interpretation of meta-characters. The safest way is to escape the value of `deviceName` before using it in the HTML string. This can be done by replacing special HTML characters (`&`, `<`, `>`, `"`, `'`) with their corresponding HTML entities. We should define a helper function (e.g., `escapeHTML`) that performs this escaping, and use it in both places where `deviceName` is interpolated into HTML (`activateDevice` and `switchToRandomDevice`). The changes are limited to the relevant JavaScript code in `examples/airpods-pitch-website.html`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
