### PR TITLE
Potential fix for code scanning alert no. 26: DOM text reinterpreted as HTML

### DIFF
--- a/examples/airpods-pitch-website.html
+++ b/examples/airpods-pitch-website.html
@@ -1172,6 +1172,17 @@
             });
         }
 
+        // Helper to escape HTML special characters
+        function escapeHTML(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;')
+                .replace(/`/g, '&#96;');
+        }
+
         function switchToRandomDevice() {
             const devices = document.querySelectorAll('.network-device');
             const randomDevice = devices[Math.floor(Math.random() * devices.length)];
@@ -1180,7 +1191,7 @@
             activateDevice(randomDevice, deviceName);
             
             const statusElement = document.getElementById('demo-status');
-            statusElement.innerHTML = `<span style="color: #667eea;">🔄 Automatically switched to ${deviceName}</span>`;
+            statusElement.innerHTML = `<span style="color: #667eea;">🔄 Automatically switched to ${escapeHTML(deviceName)}</span>`;
         }
 
         // Create floating particles


### PR DESCRIPTION
Potential fix for [https://github.com/joanalnu/joanalnu.github.io/security/code-scanning/26](https://github.com/joanalnu/joanalnu.github.io/security/code-scanning/26)

To fix this problem, we need to ensure that any untrusted data (in this case, `deviceName`) is properly escaped before being inserted into the DOM as HTML. The best way to do this is to escape any HTML meta-characters in `deviceName` so that it is treated as plain text, not as HTML. This can be done by creating a helper function that replaces special characters (`&`, `<`, `>`, `"`, `'`, and `` ` ``) with their corresponding HTML entities. 

The fix should be applied in the `switchToRandomDevice` function, specifically on line 1183, where `statusElement.innerHTML` is set. We will define an `escapeHTML` function within the script and use it to escape `deviceName` before interpolation.

No external dependencies are needed; the escaping function can be implemented inline.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
